### PR TITLE
Allow passing arguments directly to Ethereum node

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -15,6 +15,7 @@ function getOptions(program) {
     allocate: program.allocate,
     chainId: program.chainid,
     execute: program.execute,
+    nodeArguments: program.nodeArguments
   };
 }
 
@@ -46,6 +47,10 @@ program
   .option(
     "-e, --execute <command>",
     "Start ethnode, execute command, and exit ethnode (useful for testing)."
+  )
+  .option(
+    "--node-arguments <args>",
+    "Arguments that are passed directly to ethnode's underlying Ethereum node."
   );
 
 program.version(packageJson.version);

--- a/main.js
+++ b/main.js
@@ -269,7 +269,7 @@ async function run(
     throw `Client "${client}" is not supported`;
   }
 
-  args.push(nodeArguments);
+  if (nodeArguments) args.push(nodeArguments);
 
   if (logging === "debug") {
     console.log("running:", paths.binary, args.join(" "));

--- a/main.js
+++ b/main.js
@@ -157,7 +157,7 @@ async function provide(
 
 async function run(
   client,
-  { download, workdir, logging, allocate, chainId, execute }
+  { download, workdir, logging, allocate, chainId, execute, nodeArguments }
 ) {
   const loggingOptions = logging
     ? client === "geth"
@@ -268,6 +268,8 @@ async function run(
   } else {
     throw `Client "${client}" is not supported`;
   }
+
+  args.push(nodeArguments);
 
   if (logging === "debug") {
     console.log("running:", paths.binary, args.join(" "));


### PR DESCRIPTION
- Fixes #19

```bash
node cli.js openethereum --node-arguments="--version"
Run development node using configuration in /var/folders/f0/mdrzrvl938q3xb7lbm0m55zr0000gn/T/ik3ASt
Test accounts
#  Address                                    Private Key
[removed by op]

OpenEthereum Client.
  version OpenEthereum/v3.1.0-stable-2072341-20201102/x86_64-macos/rustc1.47.0
Copyright 2015-2020 Parity Technologies (UK) Ltd.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

By Wood/Paronyan/Kotewicz/Drwięga/Volf/Greeff
   Habermeier/Czaban/Gotchac/Redman/Nikolsky
   Schoedon/Tang/Adolfsson/Silva/Palm/Hirsz et al.
```

```bash
node cli.js --node-arguments="version"                                        [4/1191]
INFO [05-16|12:50:48.498] Maximum peer count                       ETH=50 LES=0 total=50
INFO [05-16|12:50:48.512] Set global gas cap                       cap=25000000
INFO [05-16|12:50:48.512] Allocated cache and file handles         database=/var/folders/f0/mdrzrvl938q3xb7lbm0m55zr0000gn/T/piPxvI/geth/data/geth/chaind
ata cache=16.00MiB handles=16
INFO [05-16|12:50:48.542] Writing custom genesis block
INFO [05-16|12:50:48.550] Persisted trie from memory database      nodes=367 size=52.21KiB time=2.393437ms gcnodes=0 gcsize=0.00B gctime=0s livenodes=1 l
ivesize=0.00B
INFO [05-16|12:50:48.550] Successfully wrote genesis state         database=chaindata hash="712286…9c428d"
INFO [05-16|12:50:48.551] Allocated cache and file handles         database=/var/folders/f0/mdrzrvl938q3xb7lbm0m55zr0000gn/T/piPxvI/geth/data/geth/lightc
haindata cache=16.00MiB handles=16
INFO [05-16|12:50:48.622] Writing custom genesis block
INFO [05-16|12:50:48.628] Persisted trie from memory database      nodes=367 size=52.21KiB time=1.407244ms gcnodes=0 gcsize=0.00B gctime=0s livenodes=1 l
ivesize=0.00B
INFO [05-16|12:50:48.628] Successfully wrote genesis state         database=lightchaindata hash="712286…9c428d"
Run development node using configuration in /var/folders/f0/mdrzrvl938q3xb7lbm0m55zr0000gn/T/piPxvI
Test accounts
#  Address                                    Private Key
[removed by op]
Geth
Version: 1.9.23-stable
Git Commit: 8c2f271528f9cccf541c6ea1c022e98407f26872
Git Commit Date: 20201015
Architecture: amd64
Protocol Versions: [65 64 63]
Go Version: go1.15.3
Operating System: darwin
GOPATH=/Users/user/go
GOROOT=go
```

- When `--nodeArguments` is missing, geth and openethereum nodes start normally.