### PR TITLE
Fix missing unzip package in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:15.11-buster-slim
 
 RUN apt-get update && apt-get install -y \
-    curl \
+    curl unzip \
  && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /home/node


### PR DESCRIPTION
- "unzip" not found when build a docker image locally using the `Dockerfile` included in the repo.