### PR TITLE
Allow passing multiple arguments to underlaying node.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,6 @@ jobs:
         with:
           username: ${{ secrets.REGISTRY_USER }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
-          registry: registry.abraham.fun
+          registry: registry.aws.abraham.fun
           repository: ${{ github.repository}}
           tag_with_ref: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,21 +2,20 @@ name: Publish Docker image
 on:
   push:
     branches:
-      - fix/nodeArguments
+      - master
+      - main
 jobs:
   push_to_registry:
-    name: Push Docker image to Registry
+    name: Push Docker image to GitHub Container Registry
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
-      - name: Push to Registry
+      - name: Push to GitHub GitHub Container Registry
         uses: docker/build-push-action@v1
         with:
-          username: ${{ secrets.REGISTRY_USER }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
-          registry: registry.abraham.fun
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ghcr.io
           repository: ${{ github.repository}}
           tag_with_ref: true
-          
-

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,3 +18,4 @@ jobs:
           registry: registry.abraham.fun
           repository: ${{ github.repository}}
           tag_with_ref: true
+          

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,19 +2,20 @@ name: Publish Docker image
 on:
   push:
     branches:
-      - fix/nodeArguments
+      - master
+      - main
 jobs:
   push_to_registry:
-    name: Push Docker image to Registry
+    name: Push Docker image to GitHub Container Registry
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
-      - name: Push to Registry
+      - name: Push to GitHub GitHub Container Registry
         uses: docker/build-push-action@v1
         with:
-          username: ${{ secrets.REGISTRY_USER }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
-          registry: registry.aws.abraham.fun
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ghcr.io
           repository: ${{ github.repository}}
           tag_with_ref: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,20 +2,19 @@ name: Publish Docker image
 on:
   push:
     branches:
-      - master
-      - main
+      - fix/nodeArguments
 jobs:
   push_to_registry:
-    name: Push Docker image to GitHub Container Registry
+    name: Push Docker image to Registry
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
-      - name: Push to GitHub GitHub Container Registry
+      - name: Push to Registry
         uses: docker/build-push-action@v1
         with:
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-          registry: ghcr.io
+          username: ${{ secrets.REGISTRY_USER }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+          registry: registry.abraham.fun
           repository: ${{ github.repository}}
           tag_with_ref: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,3 +19,4 @@ jobs:
           repository: ${{ github.repository}}
           tag_with_ref: true
           
+

--- a/cli.js
+++ b/cli.js
@@ -49,7 +49,7 @@ program
     "Start ethnode, execute command, and exit ethnode (useful for testing)."
   )
   .option(
-    "--node-arguments <args>",
+    "--node-arguments <args...>",
     "Arguments that are passed directly to ethnode's underlying Ethereum node."
   );
 

--- a/main.js
+++ b/main.js
@@ -272,7 +272,7 @@ async function run(
     throw `Client "${client}" is not supported`;
   }
 
-  if (nodeArguments) args.push(nodeArguments);
+  if (nodeArguments) args = args.concat(nodeArguments);
 
   if (logging === "debug") {
     console.log("running:", paths.binary, args.join(" "));


### PR DESCRIPTION
Running cli with multiple `--node-arguments` either by comma sepparated values or multiple instances of `--node-arguments` did not work.

This PR addresses that, while I don't know if this is the right way - it worked for my use case. 

I needed to pass `"--node-arguments=--http.addr=0.0.0.0" "--node-arguments=--http.vhosts=*"` such that it overwrite the default arguments.